### PR TITLE
Better version handling

### DIFF
--- a/soh/soh/Enhancements/randomizer/SeedContext.cpp
+++ b/soh/soh/Enhancements/randomizer/SeedContext.cpp
@@ -564,11 +564,11 @@ void Context::ParseArchipelagoOptions() {
     }
     if (slotData["shuffle_songs"] == 0) {
         mOptions[RSK_SHUFFLE_SONGS].Set(RO_SONG_SHUFFLE_OFF);
-    } else if(slotData["shuffle_songs"] == 1) {
+    } else if (slotData["shuffle_songs"] == 1) {
         mOptions[RSK_SHUFFLE_SONGS].Set(RO_SONG_SHUFFLE_SONG_LOCATIONS);
-    } else if(slotData["shuffle_songs"] == 2) {
+    } else if (slotData["shuffle_songs"] == 2) {
         mOptions[RSK_SHUFFLE_SONGS].Set(RO_SONG_SHUFFLE_DUNGEON_REWARDS);
-    } else if(slotData["shuffle_songs"] == 3) {
+    } else if (slotData["shuffle_songs"] == 3) {
         mOptions[RSK_SHUFFLE_SONGS].Set(RO_SONG_SHUFFLE_ANYWHERE);
     }
     if (slotData["shuffle_skull_tokens"] == 3) {

--- a/soh/soh/Network/Archipelago/Archipelago.cpp
+++ b/soh/soh/Network/Archipelago/Archipelago.cpp
@@ -98,16 +98,28 @@ bool ArchipelagoClient::StartClient() {
 
         slotData = data;
 
-        std::string expectedVersion = AP_Client_consts::AP_WORLD_VERSION;
-        expectedVersion = expectedVersion.substr(0, 3);
+        std::string clientVersionMajor = AP_Client_consts::AP_WORLD_VERSION_MAJOR;
+        std::string clientVersionMinor = AP_Client_consts::AP_WORLD_VERSION_MINOR;
+
+        // Get APWorld version and split it by .
         std::string apworldVersion = slotData["apworld_version"];
-        apworldVersion = apworldVersion.substr(0, 3);
-        if (apworldVersion != expectedVersion) {
+        std::stringstream ss;
+        ss << apworldVersion;
+        std::string segment;
+        std::vector<std::string> seglist;
+        while (std::getline(ss, segment, '.')) {
+            seglist.push_back(segment);
+        }
+        std::string apworldVersionMajor = seglist[0];
+        std::string apworldVersionMinor = seglist[1];
+
+        if (clientVersionMajor != apworldVersionMajor || clientVersionMinor != apworldVersionMinor) {
             disconnecting = true;
             std::string errorMessage =
                 "[ERROR] Client version does not match the APWorld version that\nwas used to generate the multiworld.\n"
                 "Supported version in this client is " +
-                expectedVersion + ".x.\nThe used APWorld is on version " + apworldVersion +
+                clientVersionMajor + "." + clientVersionMinor + ".x.\n" + "The used APWorld is on version " +
+                apworldVersionMajor + "." + apworldVersionMinor +
                 ".x instead.\nPlease use the SoH AP client matching the APWorld's version.\nAutomatically "
                 "disconnecting...";
             ArchipelagoConsole_SendMessage(errorMessage.c_str());

--- a/soh/soh/Network/Archipelago/Archipelago.cpp
+++ b/soh/soh/Network/Archipelago/Archipelago.cpp
@@ -99,13 +99,17 @@ bool ArchipelagoClient::StartClient() {
         slotData = data;
 
         std::string expectedVersion = AP_Client_consts::AP_WORLD_VERSION;
+        expectedVersion = expectedVersion.substr(0, 3);
         std::string apworldVersion = slotData["apworld_version"];
+        apworldVersion = apworldVersion.substr(0, 3);
         if (apworldVersion != expectedVersion) {
             disconnecting = true;
             std::string errorMessage =
-                "[ERROR] Client version does not match the APWorld's version.\nExpected version is " + expectedVersion +
-                ". APWorld is on version " + apworldVersion +
-                " instead.\nPlease use the SoH AP client matching the APWorld's version.\nDisconnecting...";
+                "[ERROR] Client version does not match the APWorld version that\nwas used to generate the multiworld.\n"
+                "Supported version in this client is " +
+                expectedVersion + ".x.\nThe used APWorld is on version " + apworldVersion +
+                ".x instead.\nPlease use the SoH AP client matching the APWorld's version.\nAutomatically "
+                "disconnecting...";
             ArchipelagoConsole_SendMessage(errorMessage.c_str());
             return;
         }

--- a/soh/soh/Network/Archipelago/Archipelago.h
+++ b/soh/soh/Network/Archipelago/Archipelago.h
@@ -16,7 +16,7 @@ static constexpr int MAX_PLAYER_NAME_LENGHT = 17;
 static constexpr int MAX_PASSWORD_LENGTH = 32;
 
 static constexpr char const* AP_GAME_NAME = "Ship of Harkinian";
-static constexpr char const* AP_WORLD_VERSION = "1.1.0";
+static constexpr char const* AP_WORLD_VERSION = "1.2.x";
 static constexpr int MAX_RETRIES = 3;
 } // namespace AP_Client_consts
 

--- a/soh/soh/Network/Archipelago/Archipelago.h
+++ b/soh/soh/Network/Archipelago/Archipelago.h
@@ -16,7 +16,8 @@ static constexpr int MAX_PLAYER_NAME_LENGHT = 17;
 static constexpr int MAX_PASSWORD_LENGTH = 32;
 
 static constexpr char const* AP_GAME_NAME = "Ship of Harkinian";
-static constexpr char const* AP_WORLD_VERSION = "1.2.x";
+static constexpr char const* AP_WORLD_VERSION_MAJOR = "1";
+static constexpr char const* AP_WORLD_VERSION_MINOR = "2";
 static constexpr int MAX_RETRIES = 3;
 } // namespace AP_Client_consts
 


### PR DESCRIPTION
Checks for only the first 3 characters (ea 1.2), so we can start using the last number for apworld-only bugfix version updates.

Also updated the error message to be a bit clearer when the version mismatches.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/jeromkiller/Shipwright_archipellago/actions/artifacts/5213132325.zip)
  - [soh-windows.zip](https://nightly.link/jeromkiller/Shipwright_archipellago/actions/artifacts/5213172121.zip)
<!--- section:artifacts:end -->