### PR TITLE
AP: Resize console window to fill the entire window

### DIFF
--- a/soh/soh/Network/Archipelago/ArchipelagoConsoleWindow.cpp
+++ b/soh/soh/Network/Archipelago/ArchipelagoConsoleWindow.cpp
@@ -48,7 +48,12 @@ void ArchipelagoConsoleWindow::DrawElement() {
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(15.0f, 12.0f));
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0.0f, 1.0f));
 
-    if (ImGui::BeginChild("ScrollingRegion", ImVec2(0, 400), ImGuiChildFlags_AlwaysUseWindowPadding,
+    UIWidgets::ButtonOptions sendButtonOptions = UIWidgets::ButtonOptions().Color(THEME_COLOR).Size(ImVec2(0.0, 0.0));
+    int chatbarHeight = ImGui::GetTextLineHeight() + ImGui::GetStyle().ItemSpacing.x
+        + sendButtonOptions.padding.y
+        + 5.0f * 2.0f; // FrameBorderSize * 2
+
+    if (ImGui::BeginChild("ScrollingRegion", ImVec2(0, -chatbarHeight), ImGuiChildFlags_AlwaysUseWindowPadding,
                           ImGuiWindowFlags_HorizontalScrollbar)) {
 
         for (const std::vector<AP_Text::ColoredTextNode>& line : Items) {
@@ -90,7 +95,7 @@ void ArchipelagoConsoleWindow::DrawElement() {
 
     ImGui::SameLine();
 
-    if (UIWidgets::Button("Send", UIWidgets::ButtonOptions().Color(THEME_COLOR).Size(ImVec2(0.0, 0.0)))) {
+    if (UIWidgets::Button("Send", sendButtonOptions)) {
         ArchipelagoClient::GetInstance().SendMessageToConsole(std::string(textEntryBuf));
         textEntryBuf[0] = '\0';
         keepFocus = true;


### PR DESCRIPTION
This prevents showing a window-provided scrollbar (unless it's made very small), so the user can size the console to their liking and not having to scroll the window downward to see the latest messages.
![Comparison image with the old console window (top) and new console window (bottom)](https://github.com/user-attachments/assets/b5f62437-c9c9-4a9a-8a83-281ee41a9c61)