### PR TITLE
only apply articles to clear hints

### DIFF
--- a/soh/soh/Enhancements/randomizer/hint.cpp
+++ b/soh/soh/Enhancements/randomizer/hint.cpp
@@ -520,9 +520,11 @@ const HintText Hint::GetItemHintText(uint8_t slot, bool mysterious) const {
         msg = CustomMessage({ ctx->overrides[hintedCheck].GetTrickName() });
     } else {
         const Rando::Item& item = ctx->GetItemLocation(hintedCheck)->GetPlacedItem();
-        msg = item.GetHint().GetHintMessage().GetForCurrentLanguage();
+        msg = item.GetHint().GetHintMessage().GetForCurrentLanguage(MF_RAW);
+        if (ctx->GetOption(RSK_HINT_CLARITY).Is(RO_HINT_CLARITY_CLEAR)) {
+            msg = CustomMessage(ctx->GetItemLocation(hintedCheck)->GetPlacedItem().GetArticle()) + msg;
+        }
     }
-    msg = CustomMessage(ctx->GetItemLocation(hintedCheck)->GetPlacedItem().GetArticle()) + msg;
     return HintText(msg);
 }
 

--- a/soh/soh/Enhancements/randomizer/item_list.cpp
+++ b/soh/soh/Enhancements/randomizer/item_list.cpp
@@ -1,7 +1,6 @@
 #include "soh_assets.h"
 #include "static_data.h"
 #include "SeedContext.h"
-#include "logic.h"
 #include "textures/icon_item_24_static/icon_item_24_static.h"
 #include "textures/icon_item_static/icon_item_static.h"
 #include "z64object.h"


### PR DESCRIPTION
MF_RAW while constructing CustomMessage, avoids generating \x02 after item name hint