### PR TITLE
Several client bug fixes

### DIFF
--- a/soh/soh/Enhancements/randomizer/SeedContext.cpp
+++ b/soh/soh/Enhancements/randomizer/SeedContext.cpp
@@ -392,7 +392,7 @@ GetItemEntry Context::GetArchipelagoGIEntry() {
         itemEntry.drawModIndex = fakeGiEntry->drawModIndex;
         itemEntry.drawFunc = fakeGiEntry->drawFunc;
     }
-    
+
     mAPreceiveQueue.pop();
     return itemEntry;
 }
@@ -967,7 +967,7 @@ void Context::ParseArchipelagoItemsLocations(const std::vector<ArchipelagoClient
             }
         }
     }
-    
+
     // Place vanilla shop items
     nlohmann::json vanillaShopItems = slotData["shop_vanilla_items"];
     for (auto it = vanillaShopItems.begin(); it != vanillaShopItems.end(); it++) {

--- a/soh/soh/Enhancements/randomizer/SeedContext.cpp
+++ b/soh/soh/Enhancements/randomizer/SeedContext.cpp
@@ -382,6 +382,17 @@ GetItemEntry Context::GetArchipelagoGIEntry() {
 
     Item& item = StaticData::RetrieveItem(itemId);
     GetItemEntry itemEntry = item.GetGIEntry_Copy();
+
+    if (itemEntry.modIndex == MOD_RANDOMIZER && itemEntry.getItemId == RG_ICE_TRAP) {
+        RandomizerGet iceTrapItem = ArchipelagoClient::GetInstance().GetIceTrapItem();
+        const auto fakeGiEntry = StaticData::RetrieveItem(iceTrapItem).GetGIEntry();
+        itemEntry.gid = fakeGiEntry->gid;
+        itemEntry.gi = fakeGiEntry->gi;
+        itemEntry.drawItemId = fakeGiEntry->drawItemId;
+        itemEntry.drawModIndex = fakeGiEntry->drawModIndex;
+        itemEntry.drawFunc = fakeGiEntry->drawFunc;
+    }
+    
     mAPreceiveQueue.pop();
     return itemEntry;
 }
@@ -956,7 +967,7 @@ void Context::ParseArchipelagoItemsLocations(const std::vector<ArchipelagoClient
             }
         }
     }
-
+    
     // Place vanilla shop items
     nlohmann::json vanillaShopItems = slotData["shop_vanilla_items"];
     for (auto it = vanillaShopItems.begin(); it != vanillaShopItems.end(); it++) {

--- a/soh/soh/Network/Archipelago/Archipelago.cpp
+++ b/soh/soh/Network/Archipelago/Archipelago.cpp
@@ -150,9 +150,7 @@ bool ArchipelagoClient::StartClient() {
             ResetQueue();
             SynchSentLocations();
             SynchReceivedLocations();
-            if (gPlayState != nullptr) {
-                ArchipelagoClient::SetDataStorage("scene", gPlayState->sceneNum);
-            }
+            ArchipelagoClient::SetDataStorage("scene", gPlayState->sceneNum);
         }
 
         const int team_number = apClient->get_team_number();
@@ -762,11 +760,9 @@ void ArchipelagoClient::ResetQueue() {
 }
 
 void ArchipelagoClient::OnSceneInit(uint16_t sceneNum) {
-    if (!ArchipelagoClient::IsConnected())
-        return;
-    if (gPlayState == nullptr)
-        return;
-    ArchipelagoClient::SetDataStorage("scene", sceneNum);
+    if (ArchipelagoClient::IsConnected() && GameInteractor::IsSaveLoaded(true)) {
+        ArchipelagoClient::SetDataStorage("scene", sceneNum);
+    }
 }
 
 void ArchipelagoClient::SetDataStorage(const std::string& key, const nlohmann::json& value) const {

--- a/soh/soh/Network/Archipelago/Archipelago.cpp
+++ b/soh/soh/Network/Archipelago/Archipelago.cpp
@@ -38,7 +38,6 @@ extern PlayState* gPlayState;
 }
 
 ArchipelagoClient::ArchipelagoClient() {
-    gameWon = false;
     itemQueued = false;
     disconnecting = false;
     isDeathLinkedDeath = false;
@@ -439,8 +438,6 @@ void ArchipelagoClient::GameLoaded() {
     SynchItems();
     SynchSentLocations();
     SynchReceivedLocations();
-
-    gameWon = false;
 }
 
 void ArchipelagoClient::StartLocationScouts() {
@@ -592,10 +589,7 @@ void ArchipelagoClient::SendGameWon() {
         return;
     }
 
-    if (!gameWon) {
-        apClient->StatusUpdate(APClient::ClientStatus::GOAL);
-        gameWon = true;
-    }
+    apClient->StatusUpdate(APClient::ClientStatus::GOAL);
 }
 
 void ArchipelagoClient::SendMessageToConsole(const std::string message) {

--- a/soh/soh/Network/Archipelago/Archipelago.h
+++ b/soh/soh/Network/Archipelago/Archipelago.h
@@ -127,8 +127,6 @@ class ArchipelagoClient {
     static std::shared_ptr<ArchipelagoClient> instance;
     static bool initialized;
 
-    bool gameWon;
-
     nlohmann::json slotData;
     std::set<int64_t> locations;
     std::vector<ApItem> scoutedItems;

--- a/soh/soh/Network/Archipelago/ArchipelagoConsoleWindow.h
+++ b/soh/soh/Network/Archipelago/ArchipelagoConsoleWindow.h
@@ -11,14 +11,14 @@
 class ArchipelagoConsoleWindow final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
-    ~ArchipelagoConsoleWindow() {};
+    ~ArchipelagoConsoleWindow(){};
 
     static ImVec4 getColorVal(const AP_Text::TextColor color);
 
   protected:
-    void InitElement() override {};
+    void InitElement() override{};
     void DrawElement() override;
-    void UpdateElement() override {};
+    void UpdateElement() override{};
 };
 
 void ArchipelagoConsole_SendMessage(const char* fmt, ...);

--- a/soh/soh/Network/Archipelago/ArchipelagoHintWindow.h
+++ b/soh/soh/Network/Archipelago/ArchipelagoHintWindow.h
@@ -10,12 +10,12 @@
 class ArchipelagoHintWindow final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
-    ~ArchipelagoHintWindow() {};
+    ~ArchipelagoHintWindow(){};
 
   protected:
-    void InitElement() override {};
+    void InitElement() override{};
     void DrawElement() override;
-    void UpdateElement() override {};
+    void UpdateElement() override{};
 
   private:
     enum HintTableColumns : int { COL_RECIEVING, COL_ITEM, COL_FINDING, COL_LOCATION, COL_STATUS };

--- a/soh/soh/Network/Archipelago/ArchipelagoSettingsWindow.h
+++ b/soh/soh/Network/Archipelago/ArchipelagoSettingsWindow.h
@@ -8,12 +8,12 @@
 class ArchipelagoSettingsWindow final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
-    ~ArchipelagoSettingsWindow() {};
+    ~ArchipelagoSettingsWindow(){};
 
   protected:
     void InitElement() override;
     void DrawElement() override;
-    void UpdateElement() override {};
+    void UpdateElement() override{};
 };
 
 #endif // ARCHIPELAGO_SETTINGS_WINDOW_H


### PR DESCRIPTION
Fixes https://github.com/HarbourMasters/Archipelago-SoH/issues/222
It only checked IsSaveLoaded on connecting, not when switching scenes. Also removed duplicate check in the other spot where it does SetDataStorage because it already checks for that in the IsSaveLoaded before it.

Fixes https://github.com/HarbourMasters/Archipelago-SoH/issues/66
Removes the gameWon check entirely. Not quite sure why we had it in the first place, as it wasn't sending it multiple times to the server as is, so all it did was sometimes denying the game won sending when a player reconnected to a different slot.

Fixes https://github.com/HarbourMasters/Archipelago-SoH/issues/35 and https://github.com/HarbourMasters/Archipelago-SoH/issues/13
Adds random ice trap models to ice traps received from other players. And because extra traps is using what model is showing in the ice trap + the current scene, this also fixes that those extra effects were the same when received in the same scene.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/jeromkiller/Shipwright_archipellago/actions/artifacts/6903851988.zip)
  - [soh-windows.zip](https://nightly.link/jeromkiller/Shipwright_archipellago/actions/artifacts/6903691378.zip)
  - [soh-linux.zip](https://nightly.link/jeromkiller/Shipwright_archipellago/actions/artifacts/6903676196.zip)
<!--- section:artifacts:end -->