### PR TITLE
dont sync malon egg location

### DIFF
--- a/soh/soh/Network/Archipelago/Archipelago.cpp
+++ b/soh/soh/Network/Archipelago/Archipelago.cpp
@@ -512,7 +512,7 @@ void ArchipelagoClient::SynchSentLocations() {
     for (const auto& loc : Rando::StaticData::GetLocationTable()) {
         const RandomizerCheck rc = loc.GetRandomizerCheck();
         if (Rando::Context::GetInstance()->GetItemLocation(rc)->HasObtained() &&
-            !(rc == RC_HC_MALON_EGG && RAND_GET_OPTION(RSK_SKIP_CHILD_ZELDA))) {
+            !((rc == RC_HC_MALON_EGG || rc == RC_HC_ZELDAS_LETTER) && RAND_GET_OPTION(RSK_SKIP_CHILD_ZELDA))) {
             const int64_t apLocation = apClient->get_location_id(loc.GetName());
             checkedLocations.emplace_back(apLocation);
         }

--- a/soh/soh/Network/Archipelago/Archipelago.cpp
+++ b/soh/soh/Network/Archipelago/Archipelago.cpp
@@ -511,7 +511,8 @@ void ArchipelagoClient::SynchSentLocations() {
     std::list<int64_t> checkedLocations;
     for (const auto& loc : Rando::StaticData::GetLocationTable()) {
         const RandomizerCheck rc = loc.GetRandomizerCheck();
-        if (Rando::Context::GetInstance()->GetItemLocation(rc)->HasObtained()) {
+        if (Rando::Context::GetInstance()->GetItemLocation(rc)->HasObtained() &&
+            !(rc == RC_HC_MALON_EGG && RAND_GET_OPTION(RSK_SKIP_CHILD_ZELDA))) {
             const int64_t apLocation = apClient->get_location_id(loc.GetName());
             checkedLocations.emplace_back(apLocation);
         }


### PR DESCRIPTION
This should allow for the malon location to not exist at all on the apworld side when skip child zelda is on.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/jeromkiller/Shipwright_archipellago/actions/artifacts/7277668043.zip)
  - [soh-linux.zip](https://nightly.link/jeromkiller/Shipwright_archipellago/actions/artifacts/7277270168.zip)
  - [soh-windows.zip](https://nightly.link/jeromkiller/Shipwright_archipellago/actions/artifacts/7277081845.zip)
<!--- section:artifacts:end -->