### PR TITLE
Fix data storage on scene init

### DIFF
--- a/soh/soh/Network/Archipelago/Archipelago.cpp
+++ b/soh/soh/Network/Archipelago/Archipelago.cpp
@@ -803,7 +803,7 @@ void ArchipelagoClient::ResetQueue() {
     std::swap(receiveQueue, empty);
 }
 
-void ArchipelagoClient::OnSceneInit(uint16_t sceneNum) {
+void ArchipelagoClient::AfterSceneCommands(uint16_t sceneNum) {
     if (ArchipelagoClient::IsConnected() && GameInteractor::IsSaveLoaded(true)) {
         ArchipelagoClient::SetDataStorage("scene", sceneNum);
     }
@@ -1592,8 +1592,8 @@ void RegisterArchipelago() {
         }
     });
 
-    COND_HOOK(GameInteractor::OnSceneInit, IS_ARCHIPELAGO,
-              [](int16_t sceneNum) { ArchipelagoClient::GetInstance().OnSceneInit(sceneNum); });
+    COND_HOOK(GameInteractor::AfterSceneCommands, IS_ARCHIPELAGO,
+              [](int16_t sceneNum) { ArchipelagoClient::GetInstance().AfterSceneCommands(sceneNum); });
 
     COND_HOOK(GameInteractor::OnDialogClose, IS_ARCHIPELAGO,
               []() { ArchipelagoClient::GetInstance().OnDialogCloseHook(); });

--- a/soh/soh/Network/Archipelago/Archipelago.h
+++ b/soh/soh/Network/Archipelago/Archipelago.h
@@ -91,7 +91,7 @@ class ArchipelagoClient {
     void Poll();
     void ResetQueue();
 
-    void OnSceneInit(uint16_t sceneNum);
+    void AfterSceneCommands(uint16_t sceneNum);
     void SetDataStorage(const std::string& key, const nlohmann::json& value) const;
 
     void OpenLocalHint(RandomizerCheck sohCheckId);


### PR DESCRIPTION
Fixes https://github.com/HarbourMasters/Archipelago-SoH/issues/276 by switching to a hook that executes later. Confirmed with a breakpoint that it does now reach the code to set the data storage.