### PR TITLE
Changed checkbox to filter sending junk hints to combobox

### DIFF
--- a/soh/soh/Network/Archipelago/Archipelago.cpp
+++ b/soh/soh/Network/Archipelago/Archipelago.cpp
@@ -859,7 +859,10 @@ void ArchipelagoClient::OpenLocalHint(RandomizerCheck sohCheckId) {
     }
 
     Rando::Item item = itemLoc->GetPlacedItem();
-    if (item.GetCategory() == ITEM_CATEGORY_JUNK && !CVarGetInteger(CVAR_REMOTE_ARCHIPELAGO("FillerHints"), 0)) {
+    if (item.GetCategory() == ITEM_CATEGORY_JUNK && CVarGetInteger(CVAR_REMOTE_ARCHIPELAGO("FillerHints"), 1) < 2) {
+        return;
+    }
+    if (item.GetCategory() == ITEM_CATEGORY_LESSER && CVarGetInteger(CVAR_REMOTE_ARCHIPELAGO("FillerHints"), 1) < 1) {
         return;
     }
 

--- a/soh/soh/Network/Archipelago/ArchipelagoSettingsWindow.cpp
+++ b/soh/soh/Network/Archipelago/ArchipelagoSettingsWindow.cpp
@@ -97,10 +97,17 @@ void ArchipelagoSettingsWindow::DrawElement() {
         UIWidgets::CheckboxOptions()
             .Color(THEME_COLOR)
             .Tooltip("Will limit any output to the AP console to only what effects the slot you are connected as."));
-    UIWidgets::CVarCheckbox("Open Filler Hints", CVAR_REMOTE_ARCHIPELAGO("FillerHints"),
-                            UIWidgets::CheckboxOptions()
-                                .Color(THEME_COLOR)
-                                .Tooltip("Automatically open up all hints even if they're not that useful."));
+    UIWidgets::CVarCombobox(
+        "Send clear hints to AP", CVAR_REMOTE_ARCHIPELAGO("FillerHints"),
+        { "Progressive only", "Progressive/Usefull", "All" },
+        UIWidgets::ComboboxOptions()
+            .DefaultIndex(1)
+            .Color(THEME_COLOR)
+            .Tooltip(
+                "Automatically send hints to the Archipelago room when clear hints are on for "
+                "this slot.\nThis applies to things like hovering over shop items, talking to "
+                "scrub merchants and all of the other static hint options.\n"
+                "This does not apply to Gossip Stones as they don't always give away the exact location of an item"));
 };
 
 void ArchipelagoSettingsWindow::InitElement() {

--- a/soh/soh/Network/Archipelago/ArchipelagoSettingsWindow.cpp
+++ b/soh/soh/Network/Archipelago/ArchipelagoSettingsWindow.cpp
@@ -99,7 +99,7 @@ void ArchipelagoSettingsWindow::DrawElement() {
             .Tooltip("Will limit any output to the AP console to only what effects the slot you are connected as."));
     UIWidgets::CVarCombobox(
         "Send clear hints to AP", CVAR_REMOTE_ARCHIPELAGO("FillerHints"),
-        { "Progressive only", "Progressive/Usefull", "All" },
+        { "Progressive only", "Progressive/Useful", "All" },
         UIWidgets::ComboboxOptions()
             .DefaultIndex(1)
             .Color(THEME_COLOR)

--- a/soh/soh/Network/Archipelago/ArchipelagoSettingsWindow.cpp
+++ b/soh/soh/Network/Archipelago/ArchipelagoSettingsWindow.cpp
@@ -99,7 +99,7 @@ void ArchipelagoSettingsWindow::DrawElement() {
             .Tooltip("Will limit any output to the AP console to only what effects the slot you are connected as."));
     UIWidgets::CVarCombobox(
         "Send clear hints to AP", CVAR_REMOTE_ARCHIPELAGO("FillerHints"),
-        { "Progressive only", "Progressive/Useful", "All" },
+        { "Progression only", "Progression/Useful", "All" },
         UIWidgets::ComboboxOptions()
             .DefaultIndex(1)
             .Color(THEME_COLOR)

--- a/soh/soh/Network/Archipelago/ArchipelagoSettingsWindow.cpp
+++ b/soh/soh/Network/Archipelago/ArchipelagoSettingsWindow.cpp
@@ -98,16 +98,16 @@ void ArchipelagoSettingsWindow::DrawElement() {
             .Color(THEME_COLOR)
             .Tooltip("Will limit any output to the AP console to only what effects the slot you are connected as."));
     UIWidgets::CVarCombobox(
-        "Send clear hints to AP", CVAR_REMOTE_ARCHIPELAGO("FillerHints"),
+        "Send hints to AP", CVAR_REMOTE_ARCHIPELAGO("FillerHints"),
         { "Progression only", "Progression/Useful", "All" },
         UIWidgets::ComboboxOptions()
             .DefaultIndex(1)
             .Color(THEME_COLOR)
             .Tooltip(
-                "Automatically send hints to the Archipelago room when clear hints are on for "
-                "this slot.\nThis applies to things like hovering over shop items, talking to "
-                "scrub merchants and all of the other static hint options.\n"
-                "This does not apply to Gossip Stones as they don't always give away the exact location of an item"));
+                "Automatically send hints to the Archipelago room. This applies when hovering over shop item, "
+                "or when clear hints are turned on for this slot, it will apply to things like speaking to "
+                "business scrubs and all of the other static hint options.\n\n"
+                "This does not apply to Gossip Stones as they don't always give away the exact location of an item."));
 };
 
 void ArchipelagoSettingsWindow::InitElement() {


### PR DESCRIPTION
As the title says.
This gives the player more options as to what hints they'd like to send to the AP server.
Screenshots attached, "Progressive/Useful" is the default option.

Because clear hints are public information the minimum option is "progressive" because those items are most important to keep track of.

<img width="523" height="316" alt="image" src="https://github.com/user-attachments/assets/c7974368-1d76-44a9-b442-d52089c0ead3" />

<img width="172" height="146" alt="image" src="https://github.com/user-attachments/assets/d67f0c53-16e4-4bbd-a270-c735f8776940" />


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/jeromkiller/Shipwright_archipellago/actions/artifacts/7610534365.zip)
  - [soh-windows.zip](https://nightly.link/jeromkiller/Shipwright_archipellago/actions/artifacts/7610341420.zip)
  - [soh-linux.zip](https://nightly.link/jeromkiller/Shipwright_archipellago/actions/artifacts/7610283660.zip)
<!--- section:artifacts:end -->