### PR TITLE
Parse option defaults

### DIFF
--- a/soh/soh/Enhancements/randomizer/SeedContext.cpp
+++ b/soh/soh/Enhancements/randomizer/SeedContext.cpp
@@ -497,9 +497,28 @@ void Context::ParseItemLocationsJson(nlohmann::json spoilerFileJson) {
 }
 
 void Context::ParseArchipelagoOptions() {
+    
+    // Set all options to their default before parsing them from Archipelago. This gives us
+    // a thin layer of future proofing for when Ship adds new settings down the line.
+    const auto ctx = Rando::Context::GetInstance();
+    auto& optionGroups = Rando::Settings::GetInstance()->GetOptionGroups();
+    for (size_t i = 0; i < RSG_MAX; i++) {
+        auto& optionGroup = optionGroups[i];
+        // don't go through non-menus
+        if (optionGroup.GetContainsType() == Rando::OptionGroupType::SUBGROUP) {
+            continue;
+        }
+
+        for (Rando::Option* option : optionGroup.GetOptions()) {
+            RandomizerSettingKey key = option->GetKey();
+            if (option->IsCategory(Rando::OptionCategory::Setting) && key < RSK_MAX) {
+                ctx->GetOption(key).Set(option->GetOptionDefault());
+            }
+        }
+    }
+
     // Set options to what Archipelago expects. Need to slowly convert these to options in apworld and
     // load those in instead.
-
     nlohmann::json slotData = ArchipelagoClient::GetInstance().GetSlotData();
     mOptions[RSK_LOGIC_RULES].Set(slotData["no_logic"]);
     mOptions[RSK_FOREST].Set(slotData["closed_forest"]);

--- a/soh/soh/Enhancements/randomizer/SeedContext.cpp
+++ b/soh/soh/Enhancements/randomizer/SeedContext.cpp
@@ -497,7 +497,7 @@ void Context::ParseItemLocationsJson(nlohmann::json spoilerFileJson) {
 }
 
 void Context::ParseArchipelagoOptions() {
-    
+
     // Set all options to their default before parsing them from Archipelago. This gives us
     // a thin layer of future proofing for when Ship adds new settings down the line.
     const auto ctx = Rando::Context::GetInstance();

--- a/soh/soh/Enhancements/randomizer/option.cpp
+++ b/soh/soh/Enhancements/randomizer/option.cpp
@@ -93,6 +93,10 @@ uint8_t Option::GetOptionIndex() const {
     return CVarGetInteger(cvarName.c_str(), defaultOption);
 }
 
+uint8_t Option::GetOptionDefault() const {
+    return defaultOption;
+}
+
 const std::string& Option::GetOptionText(size_t index) const {
     return options[index];
 }

--- a/soh/soh/Enhancements/randomizer/option.h
+++ b/soh/soh/Enhancements/randomizer/option.h
@@ -226,6 +226,13 @@ class Option {
     uint8_t GetOptionIndex() const;
 
     /**
+     * @brief Get the option default for this Option.
+     *
+     * @return uint8_t
+     */
+    uint8_t GetOptionDefault() const;
+
+    /**
      * @brief Set the delayedOption to the currently selected index so it can be restored later.
      */
     void SetDelayedOption();


### PR DESCRIPTION
Resolves https://github.com/HarbourMasters/Archipelago-SoH/issues/277

I've tested this by commenting out our code for skip child zelda parsing, and it properly disabled it (the yaml had it on).