### PR TITLE
Hint table improvements

### DIFF
--- a/soh/soh/Network/Archipelago/ArchipelagoHintWindow.cpp
+++ b/soh/soh/Network/Archipelago/ArchipelagoHintWindow.cpp
@@ -31,11 +31,11 @@ void ArchipelagoHintWindow::DrawElement() {
                                    ImGuiTableFlags_NoBordersInBody | ImGuiTableFlags_ScrollY;
 
     uint8_t isWindowOpen = CVarGetInteger("gOpenWindows.ArchipelagoHintWindow", 0);
-    static std::map<AP_Hint::HintStatus, const char*> showTag {
-        { AP_Hint::HintStatus::HINT_FOUND, CVAR_REMOTE_ARCHIPELAGO("ShowFoundHints")},
-        { AP_Hint::HintStatus::HINT_PRIORITY, CVAR_REMOTE_ARCHIPELAGO("ShowPriorityHints")},
-        { AP_Hint::HintStatus::HINT_NO_PRIORITY, CVAR_REMOTE_ARCHIPELAGO("ShowNoPriorityHints")},
-        { AP_Hint::HintStatus::HINT_AVOID, CVAR_REMOTE_ARCHIPELAGO("ShowAvoidHints")}
+    static std::map<AP_Hint::HintStatus, const char*> showTag{
+        { AP_Hint::HintStatus::HINT_FOUND, CVAR_REMOTE_ARCHIPELAGO("ShowFoundHints") },
+        { AP_Hint::HintStatus::HINT_PRIORITY, CVAR_REMOTE_ARCHIPELAGO("ShowPriorityHints") },
+        { AP_Hint::HintStatus::HINT_NO_PRIORITY, CVAR_REMOTE_ARCHIPELAGO("ShowNoPriorityHints") },
+        { AP_Hint::HintStatus::HINT_AVOID, CVAR_REMOTE_ARCHIPELAGO("ShowAvoidHints") }
     };
 
     ImGui::Dummy(ImVec2(0.0f, 3.0f));

--- a/soh/soh/Network/Archipelago/ArchipelagoHintWindow.cpp
+++ b/soh/soh/Network/Archipelago/ArchipelagoHintWindow.cpp
@@ -31,12 +31,11 @@ void ArchipelagoHintWindow::DrawElement() {
                                    ImGuiTableFlags_NoBordersInBody | ImGuiTableFlags_ScrollY;
 
     uint8_t isWindowOpen = CVarGetInteger("gOpenWindows.ArchipelagoHintWindow", 0);
-
-    static std::map<AP_Hint::HintStatus, bool> showTag{
-        { AP_Hint::HintStatus::HINT_FOUND, true },
-        { AP_Hint::HintStatus::HINT_PRIORITY, true },
-        { AP_Hint::HintStatus::HINT_NO_PRIORITY, true },
-        { AP_Hint::HintStatus::HINT_AVOID, true },
+    static std::map<AP_Hint::HintStatus, const char*> showTag {
+        { AP_Hint::HintStatus::HINT_FOUND, CVAR_REMOTE_ARCHIPELAGO("ShowFoundHints")},
+        { AP_Hint::HintStatus::HINT_PRIORITY, CVAR_REMOTE_ARCHIPELAGO("ShowPriorityHints")},
+        { AP_Hint::HintStatus::HINT_NO_PRIORITY, CVAR_REMOTE_ARCHIPELAGO("ShowNoPriorityHints")},
+        { AP_Hint::HintStatus::HINT_AVOID, CVAR_REMOTE_ARCHIPELAGO("ShowAvoidHints")}
     };
 
     ImGui::Dummy(ImVec2(0.0f, 3.0f));
@@ -47,16 +46,23 @@ void ArchipelagoHintWindow::DrawElement() {
         ImGui::Text("Status Filter ");
 
         ImGui::PushStyleVar(ImGuiStyleVar_SelectableTextAlign, { 0.5, 0.5 });
-        for (auto [tag, selected] : showTag) {
+        for (auto [tag, cvar] : showTag) {
             ImGui::TableNextColumn();
+            // todo, maybe create this as an element in UIWidgets
+            bool selected = CVarGetInteger(cvar, 1) == 1;
             if (selected) {
                 ImGui::PushStyleColor(ImGuiCol_Text, { 0.0f, 0.0f, 0.0f, 1.0f });
             } else {
                 ImGui::PushStyleColor(ImGuiCol_Text, AP_Text::colorVec[getStatusColor(tag)]);
             }
             ImGui::PushStyleColor(ImGuiCol_Header, AP_Text::colorVec[getStatusColor(tag)]);
-            ImGui::Selectable(AP_Hint::statusStrings[tag].c_str(), &showTag[tag]);
+            if (ImGui::Selectable(AP_Hint::statusStrings[tag].c_str(), selected)) {
+                CVarSetInteger(cvar, selected ? 0 : 1);
+                Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+                ShipInit::Init(cvar);
+            }
             ImGui::PopStyleColor(2);
+            // ===
         }
         ImGui::PopStyleVar();
         ImGui::EndTable();
@@ -78,7 +84,7 @@ void ArchipelagoHintWindow::DrawElement() {
         // content
         for (const AP_Hint::Hint& hint : HintList) {
             if (showTag.contains(hint.hint_status)) {
-                if (!showTag[hint.hint_status]) {
+                if (CVarGetInteger(showTag[hint.hint_status], 1) == 0) {
                     continue;
                 }
             }

--- a/soh/soh/Network/Archipelago/ArchipelagoHintWindow.cpp
+++ b/soh/soh/Network/Archipelago/ArchipelagoHintWindow.cpp
@@ -32,7 +32,35 @@ void ArchipelagoHintWindow::DrawElement() {
 
     uint8_t isWindowOpen = CVarGetInteger("gOpenWindows.ArchipelagoHintWindow", 0);
 
+    static std::map<AP_Hint::HintStatus, bool> showTag {
+        {AP_Hint::HintStatus::HINT_FOUND, true},
+        {AP_Hint::HintStatus::HINT_PRIORITY, true},
+        {AP_Hint::HintStatus::HINT_NO_PRIORITY, true},
+        {AP_Hint::HintStatus::HINT_AVOID, true},
+    };
+
     ImGui::Dummy(ImVec2(0.0f, 3.0f));
+
+    if (ImGui::BeginTable("archipelago_hint_tags", static_cast<int>(showTag.size()) + 1, 
+        ImGuiTableFlags_NoSavedSettings | ImGuiTableFlags_Borders)) {
+        ImGui::TableNextColumn();
+        ImGui::Text("Status Filter ");
+
+        ImGui::PushStyleVar(ImGuiStyleVar_SelectableTextAlign, {0.5, 0.5});
+        for (auto [tag, selected]: showTag) {
+            ImGui::TableNextColumn();
+            if (selected) {
+                ImGui::PushStyleColor(ImGuiCol_Text, { 0.0f, 0.0f, 0.0f, 1.0f });
+            } else {
+                ImGui::PushStyleColor(ImGuiCol_Text, AP_Text::colorVec[getStatusColor(tag)]);
+            }
+            ImGui::PushStyleColor(ImGuiCol_Header, AP_Text::colorVec[getStatusColor(tag)]);
+            ImGui::Selectable(AP_Hint::statusStrings[tag].c_str(), &showTag[tag]);
+            ImGui::PopStyleColor(2);
+        }
+        ImGui::PopStyleVar();
+        ImGui::EndTable();
+    }
 
     if (ImGui::BeginTable("archipelago_hint_table", 5, flags,
                           ImVec2(0.0f, isWindowOpen ? -hintInputHeight - 15.0f : 300.0f))) {
@@ -49,6 +77,11 @@ void ArchipelagoHintWindow::DrawElement() {
 
         // content
         for (const AP_Hint::Hint& hint : HintList) {
+            if (showTag.contains(hint.hint_status)) {
+                if (!showTag[hint.hint_status]) {
+                    continue;
+                }
+            }
             ImGui::PushID(static_cast<int>(hint.index));
             addName(hint.receiving_player_name, hint.we_receive);
             addItem(hint);

--- a/soh/soh/Network/Archipelago/ArchipelagoHintWindow.cpp
+++ b/soh/soh/Network/Archipelago/ArchipelagoHintWindow.cpp
@@ -32,22 +32,22 @@ void ArchipelagoHintWindow::DrawElement() {
 
     uint8_t isWindowOpen = CVarGetInteger("gOpenWindows.ArchipelagoHintWindow", 0);
 
-    static std::map<AP_Hint::HintStatus, bool> showTag {
-        {AP_Hint::HintStatus::HINT_FOUND, true},
-        {AP_Hint::HintStatus::HINT_PRIORITY, true},
-        {AP_Hint::HintStatus::HINT_NO_PRIORITY, true},
-        {AP_Hint::HintStatus::HINT_AVOID, true},
+    static std::map<AP_Hint::HintStatus, bool> showTag{
+        { AP_Hint::HintStatus::HINT_FOUND, true },
+        { AP_Hint::HintStatus::HINT_PRIORITY, true },
+        { AP_Hint::HintStatus::HINT_NO_PRIORITY, true },
+        { AP_Hint::HintStatus::HINT_AVOID, true },
     };
 
     ImGui::Dummy(ImVec2(0.0f, 3.0f));
 
-    if (ImGui::BeginTable("archipelago_hint_tags", static_cast<int>(showTag.size()) + 1, 
-        ImGuiTableFlags_NoSavedSettings | ImGuiTableFlags_Borders)) {
+    if (ImGui::BeginTable("archipelago_hint_tags", static_cast<int>(showTag.size()) + 1,
+                          ImGuiTableFlags_NoSavedSettings | ImGuiTableFlags_Borders)) {
         ImGui::TableNextColumn();
         ImGui::Text("Status Filter ");
 
-        ImGui::PushStyleVar(ImGuiStyleVar_SelectableTextAlign, {0.5, 0.5});
-        for (auto [tag, selected]: showTag) {
+        ImGui::PushStyleVar(ImGuiStyleVar_SelectableTextAlign, { 0.5, 0.5 });
+        for (auto [tag, selected] : showTag) {
             ImGui::TableNextColumn();
             if (selected) {
                 ImGui::PushStyleColor(ImGuiCol_Text, { 0.0f, 0.0f, 0.0f, 1.0f });

--- a/soh/soh/Network/Archipelago/ArchipelagoHintWindow.cpp
+++ b/soh/soh/Network/Archipelago/ArchipelagoHintWindow.cpp
@@ -38,7 +38,7 @@ void ArchipelagoHintWindow::DrawElement() {
                           ImVec2(0.0f, isWindowOpen ? -hintInputHeight - 15.0f : 300.0f))) {
         // headers
         ImGui::TableSetupScrollFreeze(0, 1);
-        ImGui::TableSetupColumn("Receiving Player", 0, 0.0f, HintTableColumns::COL_RECIEVING);
+        ImGui::TableSetupColumn("Receiving Player", 0, 0.0f, HintTableColumns::COL_RECEIVING);
         ImGui::TableSetupColumn("Item", 0, 0.0f, HintTableColumns::COL_ITEM);
         ImGui::TableSetupColumn("Finding Player", 0, 0.0f, HintTableColumns::COL_FINDING);
         ImGui::TableSetupColumn("Location", 0, 0.0f, HintTableColumns::COL_LOCATION);
@@ -120,7 +120,7 @@ void ArchipelagoHintWindow::DrawElement() {
         const int hintCost = ArchipelagoClient::GetInstance().GetHintCost();
         const int hintPoints = ArchipelagoClient::GetInstance().GetHintPoints();
 
-        // Todo I'd like the points to be right alligned, but It looks like Omar is still working on that
+        // Todo I'd like the points to be right aligned, but It looks like Omar is still working on that
         ImGui::TableNextColumn();
         ImGui::Dummy(ImVec2(0.0f, 3.0f));
         ImGui::Text("Hint Cost:");
@@ -246,8 +246,8 @@ AP_Text::TextColor ArchipelagoHintWindow::getStatusColor(const AP_Hint::HintStat
     return AP_Text::TextColor::COLOR_ERROR;
 }
 
-// Sort the hintlist using the stl sort
-// multi column sorting method coppied from https://pthom.github.io/imgui_explorer/ Line: 5845, func
+// Sort the hint list using the stl sort
+// multi column sorting method copied from https://pthom.github.io/imgui_explorer/ Line: 5845, func
 // CompareWithSortSpecs
 void ArchipelagoHintWindow::sortHints(ImGuiTableSortSpecs* sort_specs) {
     if (sort_specs == NULL) {
@@ -267,14 +267,30 @@ void ArchipelagoHintWindow::sortHints(ImGuiTableSortSpecs* sort_specs) {
             const ImGuiTableColumnSortSpecs* spec = &sort_specs->Specs[i];
             int delta = 0;
             switch (spec->ColumnUserID) {
-                case COL_RECIEVING:
+                case COL_RECEIVING:
                     delta = lhs.receiving_player_name.compare(rhs.receiving_player_name);
+                    // sort our player to the top or bottom for easy sorting what's yours and what isn't
+                    if (delta != 0) {
+                        if (lhs.we_receive) {
+                            delta = 1;
+                        } else if (rhs.we_receive) {
+                            delta = -1;
+                        }
+                    }
                     break;
                 case COL_ITEM:
                     delta = lhs.item_name.compare(rhs.item_name);
                     break;
                 case COL_FINDING:
                     delta = lhs.finding_player_name.compare(rhs.finding_player_name);
+                    // sort our player to the top or bottom for easy sorting what's yours and what isn't
+                    if (delta != 0) {
+                        if (lhs.we_find) {
+                            delta = 1;
+                        } else if (rhs.we_find) {
+                            delta = -1;
+                        }
+                    }
                     break;
                 case COL_LOCATION:
                     delta = lhs.location_name.compare(rhs.location_name);

--- a/soh/soh/Network/Archipelago/ArchipelagoHintWindow.h
+++ b/soh/soh/Network/Archipelago/ArchipelagoHintWindow.h
@@ -18,7 +18,7 @@ class ArchipelagoHintWindow final : public Ship::GuiWindow {
     void UpdateElement() override{};
 
   private:
-    enum HintTableColumns : int { COL_RECIEVING, COL_ITEM, COL_FINDING, COL_LOCATION, COL_STATUS };
+    enum HintTableColumns : int { COL_RECEIVING, COL_ITEM, COL_FINDING, COL_LOCATION, COL_STATUS };
 
     void addName(const std::string& name, bool is_us);
     void addItem(const AP_Hint::Hint& hint);

--- a/soh/soh/Network/Archipelago/ArchipelagoHintWindow.h
+++ b/soh/soh/Network/Archipelago/ArchipelagoHintWindow.h
@@ -10,12 +10,12 @@
 class ArchipelagoHintWindow final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
-    ~ArchipelagoHintWindow() {};
+    ~ArchipelagoHintWindow(){};
 
   protected:
-    void InitElement() override {};
+    void InitElement() override{};
     void DrawElement() override;
-    void UpdateElement() override {};
+    void UpdateElement() override{};
 
   private:
     enum HintTableColumns : int { COL_RECEIVING, COL_ITEM, COL_FINDING, COL_LOCATION, COL_STATUS };

--- a/soh/soh/Network/Archipelago/ArchipelagoHintWindow.h
+++ b/soh/soh/Network/Archipelago/ArchipelagoHintWindow.h
@@ -10,12 +10,12 @@
 class ArchipelagoHintWindow final : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
-    ~ArchipelagoHintWindow(){};
+    ~ArchipelagoHintWindow() {};
 
   protected:
-    void InitElement() override{};
+    void InitElement() override {};
     void DrawElement() override;
-    void UpdateElement() override{};
+    void UpdateElement() override {};
 
   private:
     enum HintTableColumns : int { COL_RECEIVING, COL_ITEM, COL_FINDING, COL_LOCATION, COL_STATUS };

--- a/soh/soh/Network/Archipelago/ArchipelagoTypes.h
+++ b/soh/soh/Network/Archipelago/ArchipelagoTypes.h
@@ -49,7 +49,7 @@ struct ColoredTextNode {
 }; // namespace AP_Text
 
 namespace AP_Hint {
-enum class HintStatus : char { HINT_UNSPECIFIED = 0, HINT_NO_PRIORITY, HINT_AVOID, HINT_PRIORITY, HINT_FOUND };
+enum class HintStatus : char { HINT_FOUND = 0, HINT_UNSPECIFIED, HINT_NO_PRIORITY, HINT_AVOID, HINT_PRIORITY };
 
 enum AP_Item_Flags {
     FLAG_NONE = 0,


### PR DESCRIPTION
Added status filtering, so you can hide all the hints that have already been found. or perhaps only show high priority hints.
Hints with no specific status set cannot be hidden. I've chosen to do this because hints are meant as a communication tool and won't do their job if someone just hides all hints without priority and never updates their status for other players.

hint collumns can be multi sorted, so you can push all high priority hints you have to find to the top of the list, or push all hints with no priority you're supposed to find to the bottom.

I've also changed the sorting behaviour to always rank the active player first, that way you can easily sort yourself to the top of the list.
The found hint status now ranks lower than unspecified, so it doesn't show up at the top anymore whenever you sort by highest priority first

[Screencast_20260613_155113.webm](https://github.com/user-attachments/assets/060c0a7b-9259-426b-b8b0-7a1ce3c74285)



<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/jeromkiller/Shipwright_archipellago/actions/artifacts/7612973202.zip)
  - [soh-linux.zip](https://nightly.link/jeromkiller/Shipwright_archipellago/actions/artifacts/7612668056.zip)
  - [soh-windows.zip](https://nightly.link/jeromkiller/Shipwright_archipellago/actions/artifacts/7612660429.zip)
<!--- section:artifacts:end -->