### PR TITLE
fix: Make Hints and Trap names deterministic

### DIFF
--- a/soh/soh/Enhancements/randomizer/SeedContext.cpp
+++ b/soh/soh/Enhancements/randomizer/SeedContext.cpp
@@ -456,6 +456,9 @@ void Context::ParseArchipelago() {
 
     Rando::Settings::GetInstance()->ResetExcludedLocations();
     ArchipelagoClient& apClient = ArchipelagoClient::GetInstance();
+    // Seed the RNG from the Archipelago seed up front so everything downstream is deterministic.
+    SetSeed(apClient.GetSlotData()["archipelago_seed"]);
+    Random_Init(GetSeed());
     ParseArchipelagoItemsLocations(apClient.GetScoutedItems());
     ParseArchipelagoOptions();
     ParseArchipelagoTricks();
@@ -1015,6 +1018,9 @@ void Context::ParseArchipelagoItemsLocations(const std::vector<ArchipelagoClient
 }
 
 void Context::ParseArchipelagoHints() {
+    // Clear the hint state left over from a previous save-file creation.
+    HintReset();
+
     const auto& ApHintData = ArchipelagoClient::GetInstance().foreignHints;
     const auto ctx = Rando::Context::GetInstance();
     for (const auto& ApHint : ApHintData) {

--- a/soh/soh/Enhancements/randomizer/SeedContext.cpp
+++ b/soh/soh/Enhancements/randomizer/SeedContext.cpp
@@ -914,7 +914,6 @@ void Context::ParseArchipelagoOptions() {
     mOptions[RSK_LOCK_OVERWORLD_DOORS].Set(slotData["lock_overworld_doors"]);
     mOptions[RSK_SHUFFLE_GRASS].Set(slotData["shuffle_grass"]);
     mOptions[RSK_ROCS_FEATHER].Set(slotData["rocs_feather"]);
-    SetSeed(slotData["archipelago_seed"]);
 }
 
 void Context::ParseArchipelagoTricks() {


### PR DESCRIPTION
This makes a consistent seed from the AP server apply upon file generation.
- fixes HarbourMasters/Archipelago-SoH#290

Basically two things happening here.
1. Trap names are randomized pretty early, so to make those deterministic we need to set the seed from the server earlier.
```plaintext
=== entry [4] ===
  messages:
     f1: ["They say that playing #Sun's Song# in a grave spawns #Ether Medallion#."]
     f2: ["They say that playing #Sun's Song# in a grave spawns #Magic Mirror#."]
=== entry [69] ===
  messages:
     f1: ["Some frogs holding #Progressive Blast Mask# are looking at you from underwater..."]
     f2: ["Some frogs holding #Progressive Crossbow# are looking at you from underwater..."]
```

2. The hint pool doesn't get reset completely between multiple generations.
sha1 between two save files:
- with hint reset
```plaintext
  file1 sha1: c9f251c30979bb69c7842929906b554b16d23c97
  file2 sha1: c9f251c30979bb69c7842929906b554b16d23c97
```

- without hint reset:
```plaintext
  file1 sha1: c9f251c30979bb69c7842929906b554b16d23c97
  file2 sha1: b8b9e0de0387a157dfdeb7ea2b8fb94691f816cb

     [1] fields differ: {'messages', 'distribution', 'areas', 'locations', 'type', 'hintKeys', 'items'}
        messages: f1=["L2P @."] | f2=["They say that #ReDead in the Composers' Grave# guard #Epona's Song#."]
        distribution: f1="Junk" | f2="Overworld"
        areas: f1=[] | f2=["an Isolated Place"]
        locations: f1=[] | f2=["Song from Royal Family's Tomb"]
        type: f1="Message" | f2="Item"
        hintKeys: f1=[22] | f2=[]
        items: f1=[] | f2=["Epona's Song"]
     [2] fields differ: {'messages', 'distribution', 'areas', 'locations', 'type', 'hintKeys', 'items'}
        messages: f1=["One who does not have Triforce can't go in."] | f2=["They say that the #treasure thrown by Princess Zelda# is #an Ocarina#."]
        distribution: f1="Junk" | f2="Always"
        areas: f1=[] | f2=["an Isolated Place"]
        locations: f1=[] | f2=["HF Ocarina of Time Item"]
        type: f1="Message" | f2="Item"
        hintKeys: f1=[12] | f2=[]
        items: f1=[] | f2=["Progressive Ocarina"]
```

Let me know if this is the right place to PR this. I just saw aMannus's PRs land here.
