### PR TITLE
Move goaling to entering end cutscene

### DIFF
--- a/soh/soh/Enhancements/GameplayStats/BossDefeatTimestamps.cpp
+++ b/soh/soh/Enhancements/GameplayStats/BossDefeatTimestamps.cpp
@@ -1,6 +1,5 @@
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/ShipInit.hpp"
-#include "soh/Network/Archipelago/Archipelago.h"
 
 extern "C" SaveContext gSaveContext;
 
@@ -21,7 +20,6 @@ static void RegisterBossDefeatTimestamps() {
     COND_ID_HOOK(OnBossDefeat, ACTOR_BOSS_GANON2, true, [](void* refActor) {
         gSaveContext.ship.stats.itemTimestamp[TIMESTAMP_DEFEAT_GANON] = GAMEPLAYSTAT_TOTAL_TIME;
         gSaveContext.ship.stats.gameComplete = true;
-        ArchipelagoClient::GetInstance().SendGameWon();
     });
 }
 

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -26,7 +26,6 @@
 #include "settings.h"
 #include "soh/util.h"
 #include "randomizerTypes.h"
-#include "soh/Network/Archipelago/Archipelago.h"
 #include "soh/Notification/Notification.h"
 #include "soh/ObjectExtension/ObjectExtension.h"
 
@@ -3899,7 +3898,6 @@ extern "C" u16 Randomizer_Item_Give(PlayState* play, GetItemEntry giEntry) {
                     gSaveContext.ship.stats.itemTimestamp[TIMESTAMP_TRIFORCE_COMPLETED] =
                         static_cast<u32>(GAMEPLAYSTAT_TOTAL_TIME);
                     gSaveContext.ship.stats.gameComplete = 1;
-                    ArchipelagoClient::GetInstance().SendGameWon();
                     Play_PerformSave(play);
                     Notification::Emit({
                         .message = "Game autosaved",

--- a/soh/soh/Enhancements/timesplits/TimeSplits.cpp
+++ b/soh/soh/Enhancements/timesplits/TimeSplits.cpp
@@ -9,7 +9,6 @@
 #include "soh_assets.h"
 #include <soh/SohGui/SohGui.hpp>
 #include "soh/SohGui/UIWidgets.hpp"
-#include "soh/Network/Archipelago/Archipelago.h"
 
 extern "C" {
 #include "z64item.h"
@@ -348,7 +347,6 @@ void HandleDragAndDrop(std::vector<SplitObject>& objectList, int targetIndex, co
 void TimeSplitCompleteSplits() {
     gSaveContext.ship.stats.itemTimestamp[TIMESTAMP_DEFEAT_GANON] = GAMEPLAYSTAT_TOTAL_TIME;
     gSaveContext.ship.stats.gameComplete = true;
-    ArchipelagoClient::GetInstance().SendGameWon();
 }
 
 void TimeSplitsSkipSplit(uint32_t index) {

--- a/soh/soh/Network/Archipelago/Archipelago.cpp
+++ b/soh/soh/Network/Archipelago/Archipelago.cpp
@@ -860,6 +860,11 @@ void ArchipelagoClient::AfterSceneCommands(uint16_t sceneNum) {
     if (ArchipelagoClient::IsConnected() && GameInteractor::IsSaveLoaded(true)) {
         ArchipelagoClient::SetDataStorage("scene", sceneNum);
     }
+
+    // Goal when warped to the end credits cutscene.
+    if (sceneNum == SCENE_CHAMBER_OF_THE_SAGES && gSaveContext.cutsceneIndex == 0xFFF2) {
+        SendGameWon();
+    }
 }
 
 void ArchipelagoClient::SetDataStorage(const std::string& key, const nlohmann::json& value) const {


### PR DESCRIPTION
Fixes https://github.com/HarbourMasters/Archipelago-SoH/issues/286

Tested it by beating the pig and by completing a triforce hunt.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/jeromkiller/Shipwright_archipellago/actions/artifacts/7805902993.zip)
  - [soh-windows.zip](https://nightly.link/jeromkiller/Shipwright_archipellago/actions/artifacts/7805336898.zip)
  - [soh-linux.zip](https://nightly.link/jeromkiller/Shipwright_archipellago/actions/artifacts/7805317584.zip)
<!--- section:artifacts:end -->