### PR TITLE
Remove toast and overhead collection for externally received other-slot items

### DIFF
--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -462,37 +462,47 @@ void RandomizerOnPlayerUpdateForRCQueueHandler() {
         return;
     }
 
-    GetItemEntry getItemEntry;
-    QueuedCheck queuedCheck = randomizerQueuedChecks.front();
-    RandomizerCheck rc = queuedCheck.rc;
-    auto loc = Rando::Context::GetInstance()->GetItemLocation(rc);
-    uint8_t isGiSkipped = 0;
+    // Checks that give nothing (already-obtained ones, and other slots' items from external checks) only need a flag +
+    // tracker update, so we drain all of them in this single frame rather than one-per-frame. The expensive tracker
+    // recalculation and save are batched to run once afterward instead of per check. A check that actually gives an
+    // item still goes one per frame (the give -> receive cycle can only handle one at a time), so we handle it and stop.
+    bool flaggedExternal = false;
 
-    if (rc == RC_ARCHIPELAGO_RECEIVED_ITEM) {
-        getItemEntry = Rando::Context::GetInstance()->GetArchipelagoGIEntry();
-    } else {
-        RandomizerGet vanillaRandomizerGet = Rando::StaticData::GetLocation(rc)->GetVanillaItem();
-        GetItemID vanillaItem = (GetItemID)Rando::StaticData::RetrieveItem(vanillaRandomizerGet).GetItemID();
-        getItemEntry = Rando::Context::GetInstance()->GetFinalGIEntry(rc, true, (GetItemID)vanillaRandomizerGet);
-    }
-    GetItemCategory getItemCategory = Randomizer_AdjustItemCategory(getItemEntry);
+    while (!randomizerQueuedChecks.empty()) {
+        QueuedCheck queuedCheck = randomizerQueuedChecks.front();
+        RandomizerCheck rc = queuedCheck.rc;
+        auto loc = Rando::Context::GetInstance()->GetItemLocation(rc);
 
-    // When Ocarina or Iron Boots chest has been received externally before, and then picked up in the game itself,
-    // it'll be skipped and not give the song properly because the RC is already checked off. So instead we handle
-    // it here and send out the check locked behind them manually.
-    if (loc->HasObtained()) {
-        if (rc == RC_HF_OCARINA_OF_TIME_ITEM) {
-            RandomizerOnExternalCheckHandler(RC_SONG_FROM_OCARINA_OF_TIME);
-        } else if (rc == RC_ICE_CAVERN_IRON_BOOTS_CHEST) {
-            RandomizerOnExternalCheckHandler(RC_SHEIK_IN_ICE_CAVERN);
-        } else if (rc == RC_TOT_MASTER_SWORD) {
-            RandomizerOnExternalCheckHandler(RC_GIFT_FROM_RAURU);
+        GetItemEntry getItemEntry;
+        if (rc == RC_ARCHIPELAGO_RECEIVED_ITEM) {
+            getItemEntry = Rando::Context::GetInstance()->GetArchipelagoGIEntry();
+        } else {
+            RandomizerGet vanillaRandomizerGet = Rando::StaticData::GetLocation(rc)->GetVanillaItem();
+            GetItemID vanillaItem = (GetItemID)Rando::StaticData::RetrieveItem(vanillaRandomizerGet).GetItemID();
+            getItemEntry = Rando::Context::GetInstance()->GetFinalGIEntry(rc, true, (GetItemID)vanillaRandomizerGet);
         }
-    }
+        GetItemCategory getItemCategory = Randomizer_AdjustItemCategory(getItemEntry);
 
-    if (loc->HasObtained()) {
-        SPDLOG_INFO("RC {} already obtained, skipping", static_cast<uint32_t>(rc));
-    } else {
+        // When Ocarina or Iron Boots chest has been received externally before, and then picked up in the game itself,
+        // it'll be skipped and not give the song properly because the RC is already checked off. So instead we handle
+        // it here and send out the check locked behind them manually.
+        if (loc->HasObtained()) {
+            if (rc == RC_HF_OCARINA_OF_TIME_ITEM) {
+                RandomizerOnExternalCheckHandler(RC_SONG_FROM_OCARINA_OF_TIME);
+            } else if (rc == RC_ICE_CAVERN_IRON_BOOTS_CHEST) {
+                RandomizerOnExternalCheckHandler(RC_SHEIK_IN_ICE_CAVERN);
+            } else if (rc == RC_TOT_MASTER_SWORD) {
+                RandomizerOnExternalCheckHandler(RC_GIFT_FROM_RAURU);
+            }
+
+            SPDLOG_INFO("RC {} already obtained, skipping", static_cast<uint32_t>(rc));
+            // Still fire the item-given hook as the pre-loop code did for every dequeued check; for an
+            // already-obtained check this just lets the AP client re-report the location (a no-op once it's sent).
+            GameInteractor_ExecuteOnRandomizerItemGivenHooks((uint32_t)rc, getItemEntry, 0);
+            randomizerQueuedChecks.pop();
+            continue;
+        }
+
         iceTrapScale = 0.0f;
 
         bool isItemForAnotherPlayer =
@@ -502,20 +512,21 @@ void RandomizerOnPlayerUpdateForRCQueueHandler() {
 
         if (queuedCheck.isExternal && isItemForAnotherPlayer) {
             // Another slot's item arriving from an external check: the location flag is already set, so just mark the
-            // check collected and return. Giving/dropping it would animate, sound, and toast an item we never get,
-            // and returning skips the OnRandomizerItemGiven hook (and its "<item> for <player>" toast) below.
+            // check collected. Giving/dropping it would animate, sound, and toast an item we never get; skipping the
+            // give also skips the OnRandomizerItemGiven hook (and its "<item> for <player>" toast). The heavy tracker
+            // work is deferred to the batched pass after the loop.
             SPDLOG_INFO("Skipping GetItem for other-slot item from external RC {}", static_cast<uint32_t>(rc));
 
             loc->SetCheckStatus(RCSHOW_COLLECTED);
             CheckTracker::SpoilAreaFromCheck(rc);
-            CheckTracker::RecalculateAllAreaTotals();
-            CheckTracker::RecalculateAvailableChecks();
-            SaveManager::Instance->SaveSection(gSaveContext.fileNum, SECTION_ID_TRACKER_DATA, true);
+            flaggedExternal = true;
 
             randomizerQueuedChecks.pop();
-            return;
+            continue;
         }
 
+        // This check gives an item: queue it (optionally skipping the GetItem animation) and stop for this frame.
+        uint8_t isGiSkipped = 0;
         randomizerQueuedCheck = rc;
         randomizerQueuedItemEntry = getItemEntry;
         SPDLOG_INFO("Queuing Item mod {} item {} from RC {}", getItemEntry.modIndex, getItemEntry.itemId,
@@ -543,11 +554,19 @@ void RandomizerOnPlayerUpdateForRCQueueHandler() {
 
             isGiSkipped = 1;
         }
+
+        GameInteractor_ExecuteOnRandomizerItemGivenHooks((uint32_t)rc, getItemEntry, isGiSkipped);
+
+        randomizerQueuedChecks.pop();
+        break;
     }
 
-    GameInteractor_ExecuteOnRandomizerItemGivenHooks((uint32_t)rc, getItemEntry, isGiSkipped);
-
-    randomizerQueuedChecks.pop();
+    // Batch the heavy tracker work for every silently-flagged external check into a single pass.
+    if (flaggedExternal) {
+        CheckTracker::RecalculateAllAreaTotals();
+        CheckTracker::RecalculateAvailableChecks();
+        SaveManager::Instance->SaveSection(gSaveContext.fileNum, SECTION_ID_TRACKER_DATA, true);
+    }
 }
 
 void RandomizerOnPlayerUpdateForItemQueueHandler() {

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -463,10 +463,9 @@ void RandomizerOnPlayerUpdateForRCQueueHandler() {
     }
 
     // Checks that give nothing (already-obtained ones, and other slots' items from external checks) only need a flag +
-    // tracker update, so we drain all of them in this single frame rather than one-per-frame. The expensive tracker
-    // recalculation and save are batched to run once afterward instead of per check. A check that actually gives an
-    // item still goes one per frame (the give -> receive cycle can only handle one at a time), so we handle it and
-    // stop.
+    // tracker update, so we drain all of them in this one frame instead of one-per-frame, batching the expensive
+    // tracker recalc/save to a single pass afterward. A check that actually gives an item still goes one per frame (the
+    // give -> receive cycle is one-at-a-time), so we handle it and stop.
     bool flaggedExternal = false;
 
     while (!randomizerQueuedChecks.empty()) {
@@ -479,26 +478,29 @@ void RandomizerOnPlayerUpdateForRCQueueHandler() {
             getItemEntry = Rando::Context::GetInstance()->GetArchipelagoGIEntry();
         } else {
             RandomizerGet vanillaRandomizerGet = Rando::StaticData::GetLocation(rc)->GetVanillaItem();
-            GetItemID vanillaItem = (GetItemID)Rando::StaticData::RetrieveItem(vanillaRandomizerGet).GetItemID();
             getItemEntry = Rando::Context::GetInstance()->GetFinalGIEntry(rc, true, (GetItemID)vanillaRandomizerGet);
         }
-        GetItemCategory getItemCategory = Randomizer_AdjustItemCategory(getItemEntry);
 
-        // When Ocarina or Iron Boots chest has been received externally before, and then picked up in the game itself,
-        // it'll be skipped and not give the song properly because the RC is already checked off. So instead we handle
-        // it here and send out the check locked behind them manually.
+        // The gated item (Ocarina / Iron Boots / Master Sword) was obtained externally, so the game won't unlock the
+        // check behind it normally; do it here. Fire it INTERNAL via a direct flag set, not
+        // RandomizerOnExternalCheckHandler (which would tag it external via sProcessingExternalCheck), so this
+        // player-triggered unlock shows its GetItem like a normal pickup instead of being silently flagged. All three
+        // dependents are EventChkInf checks.
         if (loc->HasObtained()) {
+            RandomizerCheck dependentRc = RC_UNKNOWN_CHECK;
             if (rc == RC_HF_OCARINA_OF_TIME_ITEM) {
-                RandomizerOnExternalCheckHandler(RC_SONG_FROM_OCARINA_OF_TIME);
+                dependentRc = RC_SONG_FROM_OCARINA_OF_TIME;
             } else if (rc == RC_ICE_CAVERN_IRON_BOOTS_CHEST) {
-                RandomizerOnExternalCheckHandler(RC_SHEIK_IN_ICE_CAVERN);
+                dependentRc = RC_SHEIK_IN_ICE_CAVERN;
             } else if (rc == RC_TOT_MASTER_SWORD) {
-                RandomizerOnExternalCheckHandler(RC_GIFT_FROM_RAURU);
+                dependentRc = RC_GIFT_FROM_RAURU;
+            }
+            if (dependentRc != RC_UNKNOWN_CHECK) {
+                Flags_SetEventChkInf(Rando::StaticData::GetLocation(dependentRc)->GetCollectionCheck().flag);
             }
 
             SPDLOG_INFO("RC {} already obtained, skipping", static_cast<uint32_t>(rc));
-            // Still fire the item-given hook as the pre-loop code did for every dequeued check; for an
-            // already-obtained check this just lets the AP client re-report the location (a no-op once it's sent).
+            // Report the location like the pre-loop code did for every dequeued check (a no-op once already sent).
             GameInteractor_ExecuteOnRandomizerItemGivenHooks((uint32_t)rc, getItemEntry, 0);
             randomizerQueuedChecks.pop();
             continue;
@@ -512,14 +514,15 @@ void RandomizerOnPlayerUpdateForRCQueueHandler() {
                                                         getItemEntry.getItemId == RG_ARCHIPELAGO_ITEM_JUNK);
 
         if (queuedCheck.isExternal && isItemForAnotherPlayer) {
-            // Another slot's item arriving from an external check: the location flag is already set, so just mark the
-            // check collected. Giving/dropping it would animate, sound, and toast an item we never get; skipping the
-            // give also skips the OnRandomizerItemGiven hook (and its "<item> for <player>" toast). The heavy tracker
-            // work is deferred to the batched pass after the loop.
+            // Another slot's item from an external check: mark it collected but give/drop nothing (no animation, sound,
+            // or over-head item we never receive). The hook still reports the location (isGiSkipped=0 keeps its
+            // "<item> for <player>" toast suppressed - that only fires for skipped gives), so a check still unknown to
+            // the server gets sent now rather than on the next save load. Heavy tracker work is batched after the loop.
             SPDLOG_INFO("Skipping GetItem for other-slot item from external RC {}", static_cast<uint32_t>(rc));
 
             loc->SetCheckStatus(RCSHOW_COLLECTED);
             CheckTracker::SpoilAreaFromCheck(rc);
+            GameInteractor_ExecuteOnRandomizerItemGivenHooks((uint32_t)rc, getItemEntry, 0);
             flaggedExternal = true;
 
             randomizerQueuedChecks.pop();
@@ -528,6 +531,7 @@ void RandomizerOnPlayerUpdateForRCQueueHandler() {
 
         // This check gives an item: queue it (optionally skipping the GetItem animation) and stop for this frame.
         uint8_t isGiSkipped = 0;
+        GetItemCategory getItemCategory = Randomizer_AdjustItemCategory(getItemEntry);
         randomizerQueuedCheck = rc;
         randomizerQueuedItemEntry = getItemEntry;
         SPDLOG_INFO("Queuing Item mod {} item {} from RC {}", getItemEntry.modIndex, getItemEntry.itemId,

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -494,23 +494,34 @@ void RandomizerOnPlayerUpdateForRCQueueHandler() {
         SPDLOG_INFO("RC {} already obtained, skipping", static_cast<uint32_t>(rc));
     } else {
         iceTrapScale = 0.0f;
-        randomizerQueuedCheck = rc;
-        randomizerQueuedItemEntry = getItemEntry;
-        SPDLOG_INFO("Queuing Item mod {} item {} from RC {}", getItemEntry.modIndex, getItemEntry.itemId,
-                    static_cast<uint32_t>(rc));
 
-        // Items only meant for other slots have no value here, so when they show up from an external check we just
-        // need the location flagged. Skip their GetItem animation no matter what the SkipGetItemAnimation setting is.
         bool isItemForAnotherPlayer =
             getItemEntry.modIndex == MOD_RANDOMIZER &&
             (getItemEntry.getItemId == RG_ARCHIPELAGO_ITEM_PROGRESSIVE ||
              getItemEntry.getItemId == RG_ARCHIPELAGO_ITEM_USEFUL || getItemEntry.getItemId == RG_ARCHIPELAGO_ITEM_JUNK);
 
         if (queuedCheck.isExternal && isItemForAnotherPlayer) {
-            Item_DropCollectible(gPlayState, &spawnPos, static_cast<int16_t>(ITEM00_SOH_GIVE_ITEM_ENTRY | 0x8000));
+            // Another slot's item arriving from an external check: the location flag is already set, so just mark the
+            // check collected and return. Giving/dropping it would animate, sound, and toast an item we never get,
+            // and returning skips the OnRandomizerItemGiven hook (and its "<item> for <player>" toast) below.
+            SPDLOG_INFO("Skipping GetItem for other-slot item from external RC {}", static_cast<uint32_t>(rc));
 
-            isGiSkipped = 1;
-        } else if (
+            loc->SetCheckStatus(RCSHOW_COLLECTED);
+            CheckTracker::SpoilAreaFromCheck(rc);
+            CheckTracker::RecalculateAllAreaTotals();
+            CheckTracker::RecalculateAvailableChecks();
+            SaveManager::Instance->SaveSection(gSaveContext.fileNum, SECTION_ID_TRACKER_DATA, true);
+
+            randomizerQueuedChecks.pop();
+            return;
+        }
+
+        randomizerQueuedCheck = rc;
+        randomizerQueuedItemEntry = getItemEntry;
+        SPDLOG_INFO("Queuing Item mod {} item {} from RC {}", getItemEntry.modIndex, getItemEntry.itemId,
+                    static_cast<uint32_t>(rc));
+
+        if (
             // Skipping ItemGet animation incompatible with checks that require closing a text box to finish
             !(rc == RC_HF_OCARINA_OF_TIME_ITEM && gPlayState->sceneNum == SCENE_HYRULE_FIELD) &&
             !(rc == RC_SPIRIT_TEMPLE_SILVER_GAUNTLETS_CHEST && gPlayState->sceneNum == SCENE_DESERT_COLOSSUS) &&

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -226,12 +226,24 @@ bool MeetsRainbowBridgeRequirements() {
 }
 
 // Todo Move this to randomizer context, clear it out on save load etc
-static std::queue<RandomizerCheck> randomizerQueuedChecks;
+// isExternal marks checks we didn't physically collect (e.g. an AP location checked off because another player
+// released their items), so we can skip the GetItem animation for items that are only for other slots.
+struct QueuedCheck {
+    RandomizerCheck rc;
+    bool isExternal;
+};
+static std::queue<QueuedCheck> randomizerQueuedChecks;
 static RandomizerCheck randomizerQueuedCheck = RC_UNKNOWN_CHECK;
 static GetItemEntry randomizerQueuedItemEntry = GET_ITEM_NONE;
 
+// Set while RandomizerOnExternalCheckHandler runs. It finishes some checks by calling Flags_Set* for the current
+// scene, which fires the flag-set hooks below; this lets those hooks know the check came from outside and not
+// from the player walking into it. Main thread only. Relies on the flag-set hooks firing synchronously from
+// within Flags_Set* (true today) - if they ever become deferred this flag would already be cleared when they run.
+static bool sProcessingExternalCheck = false;
+
 void ArchipelagoOnReceiveItem(const int32_t item) {
-    randomizerQueuedChecks.push(RC_ARCHIPELAGO_RECEIVED_ITEM);
+    randomizerQueuedChecks.push({ RC_ARCHIPELAGO_RECEIVED_ITEM, false });
     Rando::Context::GetInstance()->AddReceivedArchipelagoItem(static_cast<RandomizerGet>(item));
 }
 
@@ -282,7 +294,7 @@ void RandomizerOnFlagSetHandler(int16_t flagType, int16_t flag) {
         }
     }
     SPDLOG_INFO("Queuing RC: {}", static_cast<uint32_t>(rc));
-    randomizerQueuedChecks.push(rc);
+    randomizerQueuedChecks.push({ rc, sProcessingExternalCheck });
 }
 
 void RandomizerOnSceneFlagSetHandler(int16_t sceneNum, int16_t flagType, int16_t flag) {
@@ -351,10 +363,19 @@ void RandomizerOnSceneFlagSetHandler(int16_t sceneNum, int16_t flagType, int16_t
         return;
 
     SPDLOG_INFO("Queuing RC: {}", static_cast<uint32_t>(rc));
-    randomizerQueuedChecks.push(rc);
+    randomizerQueuedChecks.push({ rc, sProcessingExternalCheck });
 }
 
 void RandomizerOnExternalCheckHandler(uint32_t randomizerCheck) {
+    // Flag anything queued during this call as external, including checks the Flags_Set* calls below bounce back
+    // through the flag-set hooks. The guard clears it however we return.
+    sProcessingExternalCheck = true;
+    struct ExternalCheckGuard {
+        ~ExternalCheckGuard() {
+            sProcessingExternalCheck = false;
+        }
+    } externalCheckGuard;
+
     RandomizerCheck rc = static_cast<RandomizerCheck>(randomizerCheck);
     Rando::Location* loc = Rando::StaticData::GetLocation(rc);
     s32 flagID = loc->GetCollectionCheck().flag;
@@ -371,7 +392,7 @@ void RandomizerOnExternalCheckHandler(uint32_t randomizerCheck) {
     // happens, leading to a double chest spawn.
     if (rc == RC_HF_OCARINA_OF_TIME_ITEM || rc == RC_ICE_CAVERN_IRON_BOOTS_CHEST || rc == RC_FOREST_TEMPLE_BOW_CHEST ||
         rc == RC_TOT_MASTER_SWORD) {
-        randomizerQueuedChecks.push(rc);
+        randomizerQueuedChecks.push({ rc, true });
         return;
     }
 
@@ -383,7 +404,7 @@ void RandomizerOnExternalCheckHandler(uint32_t randomizerCheck) {
                 Flags_SetTreasure(gPlayState, flagID);
             } else {
                 gSaveContext.sceneFlags[scene].chest |= 1 << flagID;
-                randomizerQueuedChecks.push(rc);
+                randomizerQueuedChecks.push({ rc, true });
             }
             break;
         case SPOILER_CHK_COLLECTABLE:
@@ -391,7 +412,7 @@ void RandomizerOnExternalCheckHandler(uint32_t randomizerCheck) {
                 Flags_SetCollectible(gPlayState, flagID);
             } else {
                 gSaveContext.sceneFlags[scene].collect |= 1 << flagID;
-                randomizerQueuedChecks.push(rc);
+                randomizerQueuedChecks.push({ rc, true });
             }
             break;
         case SPOILER_CHK_RANDOMIZER_INF:
@@ -407,7 +428,7 @@ void RandomizerOnExternalCheckHandler(uint32_t randomizerCheck) {
             Flags_SetInfTable(flagID);
             break;
         case SPOILER_CHK_GOLD_SKULLTULA:
-            randomizerQueuedChecks.push(rc);
+            randomizerQueuedChecks.push({ rc, true });
             // Below doesn't work, temporarily disabled until a solution is found
             // SET_GS_FLAGS((flagID & 0x1F00) >> 8, flagID & 0xFF);
             break;
@@ -442,7 +463,8 @@ void RandomizerOnPlayerUpdateForRCQueueHandler() {
     }
 
     GetItemEntry getItemEntry;
-    RandomizerCheck rc = randomizerQueuedChecks.front();
+    QueuedCheck queuedCheck = randomizerQueuedChecks.front();
+    RandomizerCheck rc = queuedCheck.rc;
     auto loc = Rando::Context::GetInstance()->GetItemLocation(rc);
     uint8_t isGiSkipped = 0;
 
@@ -477,7 +499,18 @@ void RandomizerOnPlayerUpdateForRCQueueHandler() {
         SPDLOG_INFO("Queuing Item mod {} item {} from RC {}", getItemEntry.modIndex, getItemEntry.itemId,
                     static_cast<uint32_t>(rc));
 
-        if (
+        // Items only meant for other slots have no value here, so when they show up from an external check we just
+        // need the location flagged. Skip their GetItem animation no matter what the SkipGetItemAnimation setting is.
+        bool isItemForAnotherPlayer =
+            getItemEntry.modIndex == MOD_RANDOMIZER &&
+            (getItemEntry.getItemId == RG_ARCHIPELAGO_ITEM_PROGRESSIVE ||
+             getItemEntry.getItemId == RG_ARCHIPELAGO_ITEM_USEFUL || getItemEntry.getItemId == RG_ARCHIPELAGO_ITEM_JUNK);
+
+        if (queuedCheck.isExternal && isItemForAnotherPlayer) {
+            Item_DropCollectible(gPlayState, &spawnPos, static_cast<int16_t>(ITEM00_SOH_GIVE_ITEM_ENTRY | 0x8000));
+
+            isGiSkipped = 1;
+        } else if (
             // Skipping ItemGet animation incompatible with checks that require closing a text box to finish
             !(rc == RC_HF_OCARINA_OF_TIME_ITEM && gPlayState->sceneNum == SCENE_HYRULE_FIELD) &&
             !(rc == RC_SPIRIT_TEMPLE_SILVER_GAUNTLETS_CHEST && gPlayState->sceneNum == SCENE_DESERT_COLOSSUS) &&
@@ -2875,7 +2908,7 @@ static void RandomizerRegisterHooks() {
         // Add condition around this to only fire when loading into an Archipelago save file
         ShipInit::Init("IS_ARCHIPELAGO");
 
-        randomizerQueuedChecks = std::queue<RandomizerCheck>();
+        randomizerQueuedChecks = std::queue<QueuedCheck>();
         randomizerQueuedCheck = RC_UNKNOWN_CHECK;
         randomizerQueuedItemEntry = GET_ITEM_NONE;
 

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -465,7 +465,8 @@ void RandomizerOnPlayerUpdateForRCQueueHandler() {
     // Checks that give nothing (already-obtained ones, and other slots' items from external checks) only need a flag +
     // tracker update, so we drain all of them in this single frame rather than one-per-frame. The expensive tracker
     // recalculation and save are batched to run once afterward instead of per check. A check that actually gives an
-    // item still goes one per frame (the give -> receive cycle can only handle one at a time), so we handle it and stop.
+    // item still goes one per frame (the give -> receive cycle can only handle one at a time), so we handle it and
+    // stop.
     bool flaggedExternal = false;
 
     while (!randomizerQueuedChecks.empty()) {
@@ -506,9 +507,9 @@ void RandomizerOnPlayerUpdateForRCQueueHandler() {
         iceTrapScale = 0.0f;
 
         bool isItemForAnotherPlayer =
-            getItemEntry.modIndex == MOD_RANDOMIZER &&
-            (getItemEntry.getItemId == RG_ARCHIPELAGO_ITEM_PROGRESSIVE ||
-             getItemEntry.getItemId == RG_ARCHIPELAGO_ITEM_USEFUL || getItemEntry.getItemId == RG_ARCHIPELAGO_ITEM_JUNK);
+            getItemEntry.modIndex == MOD_RANDOMIZER && (getItemEntry.getItemId == RG_ARCHIPELAGO_ITEM_PROGRESSIVE ||
+                                                        getItemEntry.getItemId == RG_ARCHIPELAGO_ITEM_USEFUL ||
+                                                        getItemEntry.getItemId == RG_ARCHIPELAGO_ITEM_JUNK);
 
         if (queuedCheck.isExternal && isItemForAnotherPlayer) {
             // Another slot's item arriving from an external check: the location flag is already set, so just mark the


### PR DESCRIPTION
This builds on my first PR #39 where we removed the animation for external items we never collected ourself. This bypasses the item collection for the overhead AP item we'd see and bypasses the `GameInteractor_ExecuteOnRandomizerItemGivenHooks` call for the toast. 

Also we batch the external items so we don't have long pauses of ~50ms each when local items the player cares about might also come in.

We also needed to handle for some of the external logic blocking some of the event checks (Song from OoT, Iron Boots) from coming in as internal.



<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/jeromkiller/Shipwright_archipellago/actions/artifacts/7813327324.zip)
  - [soh-windows.zip](https://nightly.link/jeromkiller/Shipwright_archipellago/actions/artifacts/7812686251.zip)
  - [soh-linux.zip](https://nightly.link/jeromkiller/Shipwright_archipellago/actions/artifacts/7812626620.zip)
<!--- section:artifacts:end -->