### PR TITLE
Trap link triggers erroneously

### DIFF
--- a/soh/soh/Network/Archipelago/Archipelago.cpp
+++ b/soh/soh/Network/Archipelago/Archipelago.cpp
@@ -1708,7 +1708,7 @@ void RegisterArchipelago() {
 
     COND_HOOK(GameInteractor::OnItemReceive, IS_ARCHIPELAGO, [](GetItemEntry itemEntry) {
         // If item Received is an Ice Trap, send a Trap Link
-        if (itemEntry.itemId == RG_ICE_TRAP) {
+        if (itemEntry.itemId == RG_ICE_TRAP && itemEntry.modIndex == MOD_RANDOMIZER) {
             ArchipelagoClient::GetInstance().SendTrapLink();
         }
     });


### PR DESCRIPTION
Need this check to ensure Deku Nuts (10) doesn't also trigger this.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/jeromkiller/Shipwright_archipellago/actions/artifacts/7894582925.zip)
  - [soh-windows.zip](https://nightly.link/jeromkiller/Shipwright_archipellago/actions/artifacts/7894298389.zip)
  - [soh-linux.zip](https://nightly.link/jeromkiller/Shipwright_archipellago/actions/artifacts/7894180481.zip)
<!--- section:artifacts:end -->